### PR TITLE
fix the error in the prune cache bot workflow and add debug logs

### DIFF
--- a/.github/workflows/prune-cache-bot.yml
+++ b/.github/workflows/prune-cache-bot.yml
@@ -66,7 +66,14 @@ jobs:
               const target_ids = []
 
               for (const ref in refs) {
-                const pull_number = ref.match(/refs\/pull\/(\d+)\/merge/)?.[1]
+                console.log(`checking ${ref}...`)
+
+                const matched = ref.match(/refs\/pull\/(\d+)\/merge/)
+                if (!matched) {
+                  continue
+                }
+
+                const pull_number = matched[1]
                 const { data } = await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
## What

It was caused error on `prune cache bot` workflow.
This PR is fixing that error.

## Why

There was a cache which is having the ref which is formatted like `ref/tags/v1.x.x`.
And then, pull request number cannot get from that ref.
So, it was failed to execute get pull request API on github.