### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-frontend.yml
+++ b/.github/workflows/pull-request-frontend.yml
@@ -1,4 +1,6 @@
 name: Pull Request for Frontend
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kksys/spoon-tool/security/code-scanning/9](https://github.com/kksys/spoon-tool/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow primarily involves linting, building, and testing, it does not require write permissions. We will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
