### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-renovate.yml
+++ b/.github/workflows/pull-request-renovate.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - labeled
 
+permissions:
+  contents: read
+
 env:
   RENOVATE_TESTER_DIRECTORY: tools/renovate-tester
 


### PR DESCRIPTION
Potential fix for [https://github.com/kksys/spoon-tool/security/code-scanning/7](https://github.com/kksys/spoon-tool/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for most CI workflows that do not require write access. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
