### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 env:
   FRONTEND_DIRECTORY: packages/frontend
-
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/kksys/spoon-tool/security/code-scanning/3](https://github.com/kksys/spoon-tool/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code, installing dependencies, and uploading artifacts). Therefore, the `contents: read` permission is sufficient. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
