### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-approve-bot.yml
+++ b/.github/workflows/auto-approve-bot.yml
@@ -9,6 +9,10 @@ jobs:
     name: Auto Approve
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/approve' && github.event.issue.user.login == github.event.repository.owner.login }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     env:
       GH_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kksys/spoon-tool/security/code-scanning/2](https://github.com/kksys/spoon-tool/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow:
1. The `contents: read` permission is needed for the `actions/checkout` step.
2. The `pull-requests: write` permission is required to approve pull requests.
3. The `issues: write` permission is needed to add reactions to comments.

The `permissions` block should be added at the job level (under `approve`) to scope the permissions specifically to this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
