### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-backend.yml
+++ b/.github/workflows/pull-request-backend.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - labeled
 
+permissions:
+  contents: read
+
 env:
   BACKEND_DIRECTORY: packages/backend
 


### PR DESCRIPTION
Potential fix for [https://github.com/kksys/spoon-tool/security/code-scanning/6](https://github.com/kksys/spoon-tool/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required for the jobs. Since the workflow only performs linting and testing, it does not require write permissions. The minimal permission `contents: read` will suffice. This change will ensure that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
