### PR TITLE
remove deprecated @types/react-window-infinite-loader package

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -54,7 +54,6 @@
     "@types/node": "catalog:",
     "@types/react": "^18.3.25",
     "@types/react-dom": "^18.3.7",
-    "@types/react-window-infinite-loader": "^1.0.9",
     "@types/sanitize-html": "^2.16.0",
     "@typescript-eslint/utils": "catalog:",
     "@vitejs/plugin-react": "^5.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,9 +196,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.25)
-      '@types/react-window-infinite-loader':
-        specifier: ^1.0.9
-        version: 1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/sanitize-html':
         specifier: ^2.16.0
         version: 2.16.0
@@ -2425,13 +2422,6 @@ packages:
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
-
-  '@types/react-window-infinite-loader@1.0.9':
-    resolution: {integrity: sha512-gEInTjQwURCnDOFyIEK2+fWB5gTjqwx30O62QfxA9stE5aiB6EWkGj4UMhc0axq7/FV++Gs/TGW8FtgEx0S6Tw==}
-
-  '@types/react-window@2.0.0':
-    resolution: {integrity: sha512-E8hMDtImEpMk1SjswSvqoSmYvk7GEtyVaTa/GJV++FdDNuMVVEzpAClyJ0nqeKYBrMkGiyH6M1+rPLM0Nu1exQ==}
-    deprecated: This is a stub types definition. react-window provides its own type definitions, so you do not need this installed.
 
   '@types/react@18.3.25':
     resolution: {integrity: sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==}
@@ -9925,21 +9915,6 @@ snapshots:
   '@types/react-dom@18.3.7(@types/react@18.3.25)':
     dependencies:
       '@types/react': 18.3.25
-
-  '@types/react-window-infinite-loader@1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@types/react': 18.3.25
-      '@types/react-window': 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@types/react-window@2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react-window: 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@types/react@18.3.25':
     dependencies:


### PR DESCRIPTION
This pull request removes the `@types/react-window-infinite-loader` and its dependency `@types/react-window` from the project. These type definitions are no longer needed, likely because the corresponding packages now provide their own types.

Dependency cleanup:

* Removed `@types/react-window-infinite-loader` from the `dependencies` in `package.json` and from all relevant sections in `pnpm-lock.yaml`, streamlining type dependencies. [[1]](diffhunk://#diff-8571ecd91584b00015b23695d3a6a164282636bb47bfbe46dca243bf9b4db773L57) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL199-L201) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2429-L2435) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9929-L9943)
* Removed the related `@types/react-window` stub type definition from `pnpm-lock.yaml`, as it is deprecated and unnecessary. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2429-L2435) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9929-L9943)